### PR TITLE
feat: add an interface for window/logMessage

### DIFF
--- a/example/lsp_server_example.dart
+++ b/example/lsp_server_example.dart
@@ -9,6 +9,8 @@ void main() async {
   // But you could use a socket connection or any other stream.
   var connection = Connection(stdin, stdout);
 
+  connection.console.log('Hello, World!');
+
   // Register a listener for when the client initialzes the server.
   // You are suppose to respond with the capabilities of the server.
   // Some capabilities must be enabled by the client, you can see what the client

--- a/lib/src/lsp_server_base.dart
+++ b/lib/src/lsp_server_base.dart
@@ -2,17 +2,20 @@ import 'dart:async';
 
 import 'package:lsp_server/src/protocol/lsp_protocol/protocol_generated.dart';
 import 'package:lsp_server/src/protocol/lsp_protocol/protocol_special.dart';
+import 'package:lsp_server/src/remote_console.dart';
 import 'package:lsp_server/src/wireformat.dart';
 import 'package:json_rpc_2/json_rpc_2.dart';
 
 class Connection {
   late final Peer peer;
+  late final RemoteConsole console;
 
   Connection(
     Stream<List<int>> stream,
     StreamSink<List<int>> sink,
   ) {
     peer = Peer(lspChannel(stream, sink));
+    console = RemoteConsole(this);
   }
 
   Future listen() => peer.listen();

--- a/lib/src/remote_console.dart
+++ b/lib/src/remote_console.dart
@@ -1,0 +1,52 @@
+import 'package:lsp_server/lsp_server.dart';
+
+// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#messageType for levels and values
+const _error = 1;
+const _warn = 2;
+const _info = 3;
+const _log = 4;
+const _debug = 5;
+
+/// Ask the client to log a message in its output console or log system.
+/// Interface for [window/logMessage](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#window_logMessage).
+class RemoteConsole {
+  late Connection _connection;
+
+  RemoteConsole(Connection connection) {
+    _connection = connection;
+  }
+
+  /// Ask the client to log an error message.
+  void error(String message) {
+    _send(_error, message);
+  }
+
+  /// Ask the client to log a warning message.
+  void warn(String message) {
+    _send(_warn, message);
+  }
+
+  /// Ask the client to log an information message.
+  void info(String message) {
+    _send(_info, message);
+  }
+
+  /// Ask the client to log a message.
+  void log(String message) {
+    _send(_log, message);
+  }
+
+  /// Ask the client to log a debug message. Available since version 3.18.0 of the LSP specification.
+  void debug(String message) {
+    _send(_debug, message);
+  }
+
+  void _send(int type, String message) {
+    try {
+      _connection.sendNotification(
+          'window/logMessage', {"type": type, "message": message});
+    } catch (e) {
+      print(e);
+    }
+  }
+}


### PR DESCRIPTION
Hello 👋 Thanks for putting this package together, it's made getting started much, much easier. 

I'm coming from the Node world, having used [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node/tree/main/server) quite a bit. I noticed there were a couple of niceties from that library that I was missing from `lsp_server`, this logger being one of them. Figured I would share this with you in case you'd like to include it out of the box.

This use the same API design as the Node library, with methods on connection.console.
