### PR TITLE
chore: Re-generate from 3.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ void main() async {
       ),
     );
   });
+
+  await connection.listen();
 }
 ```
 

--- a/example/lsp_server_example.dart
+++ b/example/lsp_server_example.dart
@@ -69,6 +69,7 @@ void main() async {
     );
   });
 
+  // Start listening to peer
   await connection.listen();
 }
 

--- a/lib/src/lsp_spec/lsp_meta_model.json
+++ b/lib/src/lsp_spec/lsp_meta_model.json
@@ -53,7 +53,7 @@
 				"kind": "reference",
 				"name": "ImplementationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the implementation locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Definition} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/typeDefinition",
@@ -105,7 +105,7 @@
 				"kind": "reference",
 				"name": "TypeDefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Definition} or a\nThenable that resolves to such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Definition} or a Thenable that resolves to such."
 		},
 		{
 			"method": "workspace/workspaceFolders",
@@ -142,7 +142,7 @@
 				"kind": "reference",
 				"name": "ConfigurationParams"
 			},
-			"documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model were the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
+			"documentation": "The 'workspace/configuration' request is sent from the server to the client to fetch a certain\nconfiguration setting.\n\nThis pull model replaces the old push model where the client signaled configuration change via an\nevent. If the server still needs to react to configuration changes (since the server caches the\nresult of `workspace/configuration` requests) the server should register for an empty configuration\nchange event and empty the cache if such an event is received."
 		},
 		{
 			"method": "textDocument/documentColor",
@@ -244,6 +244,17 @@
 			"documentation": "A request to provide folding ranges in a document. The request's\nparameter is of type {@link FoldingRangeParams}, the\nresponse is of type {@link FoldingRangeList} or a Thenable\nthat resolves to such."
 		},
 		{
+			"method": "workspace/foldingRange/refresh",
+			"result": {
+				"kind": "base",
+				"name": "null"
+			},
+			"messageDirection": "serverToClient",
+			"documentation": "@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
 			"method": "textDocument/declaration",
 			"result": {
 				"kind": "or",
@@ -293,7 +304,7 @@
 				"kind": "reference",
 				"name": "DeclarationRegistrationOptions"
 			},
-			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPositionParams]\n(#TextDocumentPositionParams) the response is of type {@link Declaration}\nor a typed array of {@link DeclarationLink} or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the type definition locations of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPositionParams}\nthe response is of type {@link Declaration} or a typed array of {@link DeclarationLink}\nor a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/selectionRange",
@@ -976,6 +987,48 @@
 			"since": "3.17.0"
 		},
 		{
+			"method": "textDocument/inlineCompletion",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "reference",
+						"name": "InlineCompletionList"
+					},
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "InlineCompletionItem"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "clientToServer",
+			"params": {
+				"kind": "reference",
+				"name": "InlineCompletionParams"
+			},
+			"partialResult": {
+				"kind": "array",
+				"element": {
+					"kind": "reference",
+					"name": "InlineCompletionItem"
+				}
+			},
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "InlineCompletionRegistrationOptions"
+			},
+			"documentation": "A request to provide inline completions in a document. The request's parameter is of\ntype {@link InlineCompletionParams}, the response is of type\n{@link InlineCompletion InlineCompletion[]} or a Thenable that resolves to such.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
 			"method": "client/registerCapability",
 			"result": {
 				"kind": "base",
@@ -1232,7 +1285,7 @@
 				"kind": "reference",
 				"name": "DefinitionRegistrationOptions"
 			},
-			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the response is of either type {@link Definition}\nor a typed array of {@link DefinitionLink} or a Thenable that resolves\nto such."
+			"documentation": "A request to resolve the definition location of a symbol at a given text\ndocument position. The request's parameter is of type {@link TextDocumentPosition}\nthe response is of either type {@link Definition} or a typed array of\n{@link DefinitionLink} or a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/references",
@@ -1304,7 +1357,7 @@
 				"kind": "reference",
 				"name": "DocumentHighlightRegistrationOptions"
 			},
-			"documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type [TextDocumentPosition]\n(#TextDocumentPosition) the request response is of type [DocumentHighlight[]]\n(#DocumentHighlight) or a Thenable that resolves to such."
+			"documentation": "Request to resolve a {@link DocumentHighlight} for a given\ntext document position. The request's parameter is of type {@link TextDocumentPosition}\nthe request response is an array of type {@link DocumentHighlight}\nor a Thenable that resolves to such."
 		},
 		{
 			"method": "textDocument/documentSymbol",
@@ -1663,6 +1716,37 @@
 				"name": "DocumentRangeFormattingRegistrationOptions"
 			},
 			"documentation": "A request to format a range in a document."
+		},
+		{
+			"method": "textDocument/rangesFormatting",
+			"result": {
+				"kind": "or",
+				"items": [
+					{
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "TextEdit"
+						}
+					},
+					{
+						"kind": "base",
+						"name": "null"
+					}
+				]
+			},
+			"messageDirection": "clientToServer",
+			"params": {
+				"kind": "reference",
+				"name": "DocumentRangesFormattingParams"
+			},
+			"registrationOptions": {
+				"kind": "reference",
+				"name": "DocumentRangeFormattingRegistrationOptions"
+			},
+			"documentation": "A request to format ranges in a document.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"method": "textDocument/onTypeFormatting",
@@ -3651,7 +3735,7 @@
 						"kind": "reference",
 						"name": "Position"
 					},
-					"documentation": "The position of this hint."
+					"documentation": "The position of this hint.\n\nIf multiple hints have the same position, they will be shown in the order\nthey appear in the response."
 				},
 				{
 					"name": "label",
@@ -4034,6 +4118,128 @@
 			],
 			"documentation": "The params sent in a close notebook document notification.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "InlineCompletionParams",
+			"properties": [
+				{
+					"name": "context",
+					"type": {
+						"kind": "reference",
+						"name": "InlineCompletionContext"
+					},
+					"documentation": "Additional information about the context in which inline completions were\nrequested."
+				}
+			],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "TextDocumentPositionParams"
+				}
+			],
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "WorkDoneProgressParams"
+				}
+			],
+			"documentation": "A parameter literal used in inline completion requests.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
+			"name": "InlineCompletionList",
+			"properties": [
+				{
+					"name": "items",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "InlineCompletionItem"
+						}
+					},
+					"documentation": "The inline completion items"
+				}
+			],
+			"documentation": "Represents a collection of {@link InlineCompletionItem inline completion items} to be presented in the editor.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
+			"name": "InlineCompletionItem",
+			"properties": [
+				{
+					"name": "insertText",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "string"
+							},
+							{
+								"kind": "reference",
+								"name": "StringValue"
+							}
+						]
+					},
+					"documentation": "The text to replace the range with. Must be set."
+				},
+				{
+					"name": "filterText",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"optional": true,
+					"documentation": "A text that is used to decide if this inline completion should be shown. When `falsy` the {@link InlineCompletionItem.insertText} is used."
+				},
+				{
+					"name": "range",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					},
+					"optional": true,
+					"documentation": "The range to replace. Must begin and end on the same line."
+				},
+				{
+					"name": "command",
+					"type": {
+						"kind": "reference",
+						"name": "Command"
+					},
+					"optional": true,
+					"documentation": "An optional {@link Command} that is executed *after* inserting this completion."
+				}
+			],
+			"documentation": "An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
+			"name": "InlineCompletionRegistrationOptions",
+			"properties": [],
+			"extends": [
+				{
+					"kind": "reference",
+					"name": "InlineCompletionOptions"
+				},
+				{
+					"kind": "reference",
+					"name": "TextDocumentRegistrationOptions"
+				}
+			],
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "StaticRegistrationOptions"
+				}
+			],
+			"documentation": "Inline completion options used during static or dynamic registration.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "RegistrationParams",
@@ -4504,7 +4710,7 @@
 						"name": "CompletionContext"
 					},
 					"optional": true,
-					"documentation": "The completion context. This is only available it the client specifies\nto send this using the client capability `textDocument.completion.contextSupport === true`"
+					"documentation": "The completion context. This is only available if the client specifies\nto send this using the client capability `textDocument.completion.contextSupport === true`"
 				}
 			],
 			"extends": [
@@ -5623,7 +5829,7 @@
 						"name": "LSPAny"
 					},
 					"optional": true,
-					"documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a [CodeLensResolveRequest]\n(#CodeLensResolveRequest)"
+					"documentation": "A data entry field that is preserved on a code lens item between\na {@link CodeLensRequest} and a {@link CodeLensResolveRequest}"
 				}
 			],
 			"documentation": "A code lens represents a {@link Command command} that should be shown along with\nsource text, like the number of references, a way to run tests, etc.\n\nA code lens is _unresolved_ when no command is associated to it. For performance\nreasons the creation of a code lens and resolving should be done in two stages."
@@ -5817,6 +6023,47 @@
 				}
 			],
 			"documentation": "Registration options for a {@link DocumentRangeFormattingRequest}."
+		},
+		{
+			"name": "DocumentRangesFormattingParams",
+			"properties": [
+				{
+					"name": "textDocument",
+					"type": {
+						"kind": "reference",
+						"name": "TextDocumentIdentifier"
+					},
+					"documentation": "The document to format."
+				},
+				{
+					"name": "ranges",
+					"type": {
+						"kind": "array",
+						"element": {
+							"kind": "reference",
+							"name": "Range"
+						}
+					},
+					"documentation": "The ranges to format"
+				},
+				{
+					"name": "options",
+					"type": {
+						"kind": "reference",
+						"name": "FormattingOptions"
+					},
+					"documentation": "The format options"
+				}
+			],
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "WorkDoneProgressParams"
+				}
+			],
+			"documentation": "The parameters of a {@link DocumentRangesFormattingRequest}.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "DocumentOnTypeFormattingParams",
@@ -6080,7 +6327,7 @@
 						"name": "uinteger"
 					},
 					"optional": true,
-					"documentation": "Optional progress percentage to display (value 100 is considered 100%).\nIf not provided infinite progress is assumed and clients are allowed\nto ignore the `percentage` value in subsequent in report notifications.\n\nThe value should be steadily rising. Clients are free to ignore values\nthat are not following this rule. The value range is [0, 100]."
+					"documentation": "Optional progress percentage to display (value 100 is considered 100%).\nIf not provided infinite progress is assumed and clients are allowed\nto ignore the `percentage` value in subsequent report notifications.\n\nThe value should be steadily rising. Clients are free to ignore values\nthat are not following this rule. The value range is [0, 100]."
 				}
 			]
 		},
@@ -6119,7 +6366,7 @@
 						"name": "uinteger"
 					},
 					"optional": true,
-					"documentation": "Optional progress percentage to display (value 100 is considered 100%).\nIf not provided infinite progress is assumed and clients are allowed\nto ignore the `percentage` value in subsequent in report notifications.\n\nThe value should be steadily rising. Clients are free to ignore values\nthat are not following this rule. The value range is [0, 100]"
+					"documentation": "Optional progress percentage to display (value 100 is considered 100%).\nIf not provided infinite progress is assumed and clients are allowed\nto ignore the `percentage` value in subsequent report notifications.\n\nThe value should be steadily rising. Clients are free to ignore values\nthat are not following this rule. The value range is [0, 100]."
 				}
 			]
 		},
@@ -6400,7 +6647,7 @@
 					"name": "scopeUri",
 					"type": {
 						"kind": "base",
-						"name": "string"
+						"name": "URI"
 					},
 					"optional": true,
 					"documentation": "The scope to get the configuration section for."
@@ -6518,7 +6765,7 @@
 					"documentation": "Character offset on a line in a document (zero-based).\n\nThe meaning of this offset is determined by the negotiated\n`PositionEncodingKind`.\n\nIf the character value is greater than the line length it defaults back to the\nline length."
 				}
 			],
-			"documentation": "Position in a text document expressed as zero-based line and character\noffset. Prior to 3.17 the offsets were always based on a UTF-16 string\nrepresentation. So a string of the form `a𐐀b` the character offset of the\ncharacter `a` is 0, the character offset of `𐐀` is 1 and the character\noffset of b is 3 since `𐐀` is represented using two code units in UTF-16.\nSince 3.17 clients and servers can agree on a different string encoding\nrepresentation (e.g. UTF-8). The client announces it's supported encoding\nvia the client capability [`general.positionEncodings`](#clientCapabilities).\nThe value is an array of position encodings the client supports, with\ndecreasing preference (e.g. the encoding at index `0` is the most preferred\none). To stay backwards compatible the only mandatory encoding is UTF-16\nrepresented via the string `utf-16`. The server can pick one of the\nencodings offered by the client and signals that encoding back to the\nclient via the initialize result's property\n[`capabilities.positionEncoding`](#serverCapabilities). If the string value\n`utf-16` is missing from the client's capability `general.positionEncodings`\nservers can safely assume that the client supports UTF-16. If the server\nomits the position encoding in its initialize result the encoding defaults\nto the string value `utf-16`. Implementation considerations: since the\nconversion from one encoding into another requires the content of the\nfile / line the conversion is best done where the file is read which is\nusually on the server side.\n\nPositions are line end character agnostic. So you can not specify a position\nthat denotes `\\r|\\n` or `\\n|` where `|` represents the character offset.\n\n@since 3.17.0 - support for negotiated position encoding.",
+			"documentation": "Position in a text document expressed as zero-based line and character\noffset. Prior to 3.17 the offsets were always based on a UTF-16 string\nrepresentation. So a string of the form `a𐐀b` the character offset of the\ncharacter `a` is 0, the character offset of `𐐀` is 1 and the character\noffset of b is 3 since `𐐀` is represented using two code units in UTF-16.\nSince 3.17 clients and servers can agree on a different string encoding\nrepresentation (e.g. UTF-8). The client announces it's supported encoding\nvia the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).\nThe value is an array of position encodings the client supports, with\ndecreasing preference (e.g. the encoding at index `0` is the most preferred\none). To stay backwards compatible the only mandatory encoding is UTF-16\nrepresented via the string `utf-16`. The server can pick one of the\nencodings offered by the client and signals that encoding back to the\nclient via the initialize result's property\n[`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value\n`utf-16` is missing from the client's capability `general.positionEncodings`\nservers can safely assume that the client supports UTF-16. If the server\nomits the position encoding in its initialize result the encoding defaults\nto the string value `utf-16`. Implementation considerations: since the\nconversion from one encoding into another requires the content of the\nfile / line the conversion is best done where the file is read which is\nusually on the server side.\n\nPositions are line end character agnostic. So you can not specify a position\nthat denotes `\\r|\\n` or `\\n|` where `|` represents the character offset.\n\n@since 3.17.0 - support for negotiated position encoding.",
 			"since": "3.17.0 - support for negotiated position encoding."
 		},
 		{
@@ -7595,6 +7842,68 @@
 			"since": "3.17.0"
 		},
 		{
+			"name": "InlineCompletionContext",
+			"properties": [
+				{
+					"name": "triggerKind",
+					"type": {
+						"kind": "reference",
+						"name": "InlineCompletionTriggerKind"
+					},
+					"documentation": "Describes how the inline completion was triggered."
+				},
+				{
+					"name": "selectedCompletionInfo",
+					"type": {
+						"kind": "reference",
+						"name": "SelectedCompletionInfo"
+					},
+					"optional": true,
+					"documentation": "Provides information about the currently selected item in the autocomplete widget if it is visible."
+				}
+			],
+			"documentation": "Provides information about the context in which an inline completion was requested.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
+			"name": "StringValue",
+			"properties": [
+				{
+					"name": "kind",
+					"type": {
+						"kind": "stringLiteral",
+						"value": "snippet"
+					},
+					"documentation": "The kind of string value."
+				},
+				{
+					"name": "value",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The snippet string."
+				}
+			],
+			"documentation": "A string value used as a snippet is a template which allows to insert text\nand to control the editor cursor when insertion happens.\n\nA snippet can define tab stops and placeholders with `$1`, `$2`\nand `${3:foo}`. `$0` defines the final tab stop, it defaults to\nthe end of the snippet. Variables are defined with `$name` and\n`${name:default value}`.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
+			"name": "InlineCompletionOptions",
+			"mixins": [
+				{
+					"kind": "reference",
+					"name": "WorkDoneProgressOptions"
+				}
+			],
+			"properties": [],
+			"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
 			"name": "Registration",
 			"properties": [
 				{
@@ -8397,6 +8706,26 @@
 					"optional": true,
 					"documentation": "The server has support for pull model diagnostics.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "inlineCompletionProvider",
+					"type": {
+						"kind": "or",
+						"items": [
+							{
+								"kind": "base",
+								"name": "boolean"
+							},
+							{
+								"kind": "reference",
+								"name": "InlineCompletionOptions"
+							}
+						]
+					},
+					"optional": true,
+					"documentation": "Inline completion options used during static registration.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				},
 				{
 					"name": "workspace",
@@ -9231,7 +9560,19 @@
 		},
 		{
 			"name": "DocumentRangeFormattingOptions",
-			"properties": [],
+			"properties": [
+				{
+					"name": "rangesSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the server supports formatting multiple ranges at once.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
+				}
+			],
 			"mixins": [
 				{
 					"kind": "reference",
@@ -9495,7 +9836,7 @@
 						"kind": "base",
 						"name": "string"
 					},
-					"documentation": "The glob pattern to match. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
+					"documentation": "The glob pattern to match. Glob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)"
 				},
 				{
 					"name": "matches",
@@ -9670,6 +10011,30 @@
 			],
 			"documentation": "A change describing how to move a `NotebookCell`\narray from state S to S'.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "SelectedCompletionInfo",
+			"properties": [
+				{
+					"name": "range",
+					"type": {
+						"kind": "reference",
+						"name": "Range"
+					},
+					"documentation": "The range that will be replaced if this completion item is accepted."
+				},
+				{
+					"name": "text",
+					"type": {
+						"kind": "base",
+						"name": "string"
+					},
+					"documentation": "The text the range will be replaced with if this completion is accepted."
+				}
+			],
+			"documentation": "Describes the currently selected completion item.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "ClientCapabilities",
@@ -10316,6 +10681,17 @@
 					"optional": true,
 					"documentation": "Capabilities specific to the diagnostic requests scoped to the\nworkspace.\n\n@since 3.17.0.",
 					"since": "3.17.0."
+				},
+				{
+					"name": "foldingRange",
+					"type": {
+						"kind": "reference",
+						"name": "FoldingRangeWorkspaceClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Capabilities specific to the folding range requests scoped to the workspace.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			],
 			"documentation": "Workspace specific client capabilities."
@@ -10606,6 +10982,17 @@
 					"optional": true,
 					"documentation": "Capabilities specific to the diagnostic pull model.\n\n@since 3.17.0",
 					"since": "3.17.0"
+				},
+				{
+					"name": "inlineCompletion",
+					"type": {
+						"kind": "reference",
+						"name": "InlineCompletionClientCapabilities"
+					},
+					"optional": true,
+					"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			],
 			"documentation": "Text document specific client capabilities."
@@ -11123,6 +11510,25 @@
 			],
 			"documentation": "Workspace client capabilities specific to diagnostic pull requests.\n\n@since 3.17.0",
 			"since": "3.17.0"
+		},
+		{
+			"name": "FoldingRangeWorkspaceClientCapabilities",
+			"properties": [
+				{
+					"name": "refreshSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client implementation supports a refresh request sent from the\nserver to the client.\n\nNote that this event is global and will force the client to refresh all\nfolding ranges currently shown. It should be used with absolute care and is\nuseful for situation where a server for example detects a project wide\nchange that requires such a calculation.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
+				}
+			],
+			"documentation": "Client workspace capabilities specific to folding ranges\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "TextDocumentSyncClientCapabilities",
@@ -11912,6 +12318,17 @@
 					},
 					"optional": true,
 					"documentation": "Whether range formatting supports dynamic registration."
+				},
+				{
+					"name": "rangesSupport",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether the client supports formatting multiple ranges at once.\n\n@since 3.18.0\n@proposed",
+					"since": "3.18.0",
+					"proposed": true
 				}
 			],
 			"documentation": "Client capabilities of a {@link DocumentRangeFormattingRequest}."
@@ -12431,6 +12848,23 @@
 			"since": "3.17.0"
 		},
 		{
+			"name": "InlineCompletionClientCapabilities",
+			"properties": [
+				{
+					"name": "dynamicRegistration",
+					"type": {
+						"kind": "base",
+						"name": "boolean"
+					},
+					"optional": true,
+					"documentation": "Whether implementation supports dynamic registration for inline completion providers."
+				}
+			],
+			"documentation": "Client capabilities specific to inline completions.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
+		},
+		{
 			"name": "NotebookDocumentSyncClientCapabilities",
 			"properties": [
 				{
@@ -12807,7 +13241,7 @@
 				{
 					"name": "RequestCancelled",
 					"value": -32800,
-					"documentation": "The client has canceled a request and a server as detected\nthe cancel."
+					"documentation": "The client has canceled a request and a server has detected\nthe cancel."
 				}
 			],
 			"supportsCustomValues": true
@@ -13077,6 +13511,12 @@
 					"name": "Log",
 					"value": 4,
 					"documentation": "A log message."
+				},
+				{
+					"name": "Debug",
+					"value": 5,
+					"documentation": "A debug message.\n\n@since 3.18.0",
+					"since": "3.18.0"
 				}
 			],
 			"documentation": "The message type"
@@ -13423,6 +13863,28 @@
 				}
 			],
 			"documentation": "Describes the content type that a client supports in various\nresult literals like `Hover`, `ParameterInfo` or `CompletionItem`.\n\nPlease note that `MarkupKinds` must not start with a `$`. This kinds\nare reserved for internal usage."
+		},
+		{
+			"name": "InlineCompletionTriggerKind",
+			"type": {
+				"kind": "base",
+				"name": "uinteger"
+			},
+			"values": [
+				{
+					"name": "Invoked",
+					"value": 0,
+					"documentation": "Completion was triggered explicitly by a user gesture."
+				},
+				{
+					"name": "Automatic",
+					"value": 1,
+					"documentation": "Completion was triggered automatically while editing."
+				}
+			],
+			"documentation": "Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.\n\n@since 3.18.0\n@proposed",
+			"since": "3.18.0",
+			"proposed": true
 		},
 		{
 			"name": "PositionEncodingKind",
@@ -14175,7 +14637,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}
@@ -14208,7 +14670,7 @@
 										"name": "string"
 									},
 									"optional": true,
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}
@@ -14241,14 +14703,14 @@
 										"kind": "base",
 										"name": "string"
 									},
-									"documentation": "A glob pattern, like `*.{ts,js}`."
+									"documentation": "A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples."
 								}
 							]
 						}
 					}
 				]
 			},
-			"documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
+			"documentation": "A document filter denotes a document by different properties like\nthe {@link TextDocument.languageId language}, the {@link Uri.scheme scheme} of\nits resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.\n\nGlob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@sample A language filter that applies to typescript files on disk: `{ language: 'typescript', scheme: 'file' }`\n@sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`\n\n@since 3.17.0",
 			"since": "3.17.0"
 		},
 		{
@@ -14366,7 +14828,7 @@
 				"kind": "base",
 				"name": "string"
 			},
-			"documentation": "The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:\n- `*` to match one or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@since 3.17.0",
+			"documentation": "The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:\n- `*` to match zero or more characters in a path segment\n- `?` to match on one character in a path segment\n- `**` to match any number of path segments, including none\n- `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)\n- `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)\n- `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)\n\n@since 3.17.0",
 			"since": "3.17.0"
 		}
 	]

--- a/lib/src/lsp_spec/lsp_meta_model.license.txt
+++ b/lib/src/lsp_spec/lsp_meta_model.license.txt
@@ -5,11 +5,398 @@ lsp_meta_model.json downloaded from: https://microsoft.github.io/language-server
 
 --
 
-Copyright (c) Microsoft Corporation.
+Attribution 4.0 International
 
-All rights reserved.
+=======================================================================
 
-Distributed under the following terms:
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-1.	Documentation is licensed under the Creative Commons Attribution 3.0 United States License. Code is licensed under the MIT License.
-2. This license does not grant you rights to use any trademarks or logos of Microsoft. For Microsoft’s general trademark guidelines, go to http://go.microsoft.com/fwlink/?LinkID=254653
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public:
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/lib/src/protocol/lsp_protocol/protocol_generated.dart
+++ b/lib/src/protocol/lsp_protocol/protocol_generated.dart
@@ -18627,7 +18627,7 @@ class InsertTextMode implements ToJsonable {
   /// The editor adjusts leading whitespace of new lines so that they match the
   /// indentation up to the cursor of the line for which the item is accepted.
   ///
-  /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a multi
+  /// Consider a line like this: `<2tabs><cursor><3tabs>foo`. Accepting a multi
   /// line completion item is indented using 2 tabs and all following lines
   /// inserted will be indented using 2 tabs as well.
   static const adjustIndentation = InsertTextMode(2);

--- a/lib/src/protocol/lsp_protocol/protocol_generated.dart
+++ b/lib/src/protocol/lsp_protocol/protocol_generated.dart
@@ -104,7 +104,7 @@ typedef LSPArray = List<LSPAny>;
 
 /// The glob pattern to watch relative to the base path. Glob patterns can have
 /// the following syntax:
-/// - `*` to match one or more characters in a path segment
+/// - `*` to match zero or more characters in a path segment
 /// - `?` to match on one character in a path segment
 /// - `**` to match any number of path segments, including none
 /// - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and
@@ -156,22 +156,24 @@ typedef TextDocumentContentChangeEvent
 
 /// Result for a request to resolve the type definition locations of a symbol at
 /// a given text document position. The request's parameter is of type
-/// [TextDocumentPositionParams] the response is of type [Declaration]
-/// or a typed array of [DeclarationLink] or a [Future] that resolves to such.
+/// [TextDocumentPositionParams]
+/// the response is of type [Declaration] or a typed array of [DeclarationLink]
+/// or a [Future] that resolves to such.
 typedef TextDocumentDeclarationResult
     = Either2<Declaration, List<DeclarationLink>>?;
 
 /// Result for a request to resolve the definition location of a symbol at a
 /// given text document position. The request's parameter is of type
-/// [TextDocumentPosition] the response is of either type [Definition]
-/// or a typed array of [DefinitionLink] or a [Future] that resolves to such.
+/// [TextDocumentPosition]
+/// the response is of either type [Definition] or a typed array of
+/// [DefinitionLink] or a [Future] that resolves to such.
 typedef TextDocumentDefinitionResult
     = Either2<Definition, List<DefinitionLink>>?;
 
 /// Result for request to resolve a [DocumentHighlight] for a given text
 /// document position. The request's parameter is of type [TextDocumentPosition]
-/// the request response is of type [DocumentHighlight] or a [Future] that
-/// resolves to such.
+/// the request response is an array of type [DocumentHighlight]
+/// or a [Future] that resolves to such.
 typedef TextDocumentDocumentHighlightResult = List<DocumentHighlight>?;
 
 /// Result for a request to provide document links
@@ -188,7 +190,7 @@ typedef TextDocumentDocumentSymbolResult
 /// glob-pattern that is applied to the [TextDocument.fileName].
 ///
 /// Glob patterns can have the following syntax:
-/// - `*` to match one or more characters in a path segment
+/// - `*` to match zero or more characters in a path segment
 /// - `?` to match on one character in a path segment
 /// - `**` to match any number of path segments, including none
 /// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}`
@@ -222,8 +224,8 @@ typedef TextDocumentHoverResult = Hover?;
 
 /// Result for a request to resolve the implementation locations of a symbol at
 /// a given text document position. The request's parameter is of type
-/// [TextDocumentPositionParams] the response is of type [Definition] or a
-/// [Future] that resolves to such.
+/// [TextDocumentPositionParams]
+/// the response is of type [Definition] or a [Future] that resolves to such.
 typedef TextDocumentImplementationResult
     = Either2<Definition, List<DefinitionLink>>?;
 
@@ -233,6 +235,16 @@ typedef TextDocumentImplementationResult
 ///
 /// @since 3.17.0
 typedef TextDocumentInlayHintResult = List<InlayHint>?;
+
+/// Result for a request to provide inline completions in a document. The
+/// request's parameter is of type [InlineCompletionParams], the response is of
+/// type
+/// [InlineCompletion] or a [Future] that resolves to such.
+///
+/// @since 3.18.0
+/// @proposed
+typedef TextDocumentInlineCompletionResult
+    = Either2<InlineCompletionList, List<InlineCompletionItem>>?;
 
 /// Result for a request to provide inline values in a document. The request's
 /// parameter is of type [InlineValueParams], the response is of type
@@ -276,6 +288,12 @@ typedef TextDocumentPrepareTypeHierarchyResult = List<TypeHierarchyItem>?;
 /// Result for a request to format a range in a document.
 typedef TextDocumentRangeFormattingResult = List<TextEdit>?;
 
+/// Result for a request to format ranges in a document.
+///
+/// @since 3.18.0
+/// @proposed
+typedef TextDocumentRangesFormattingResult = List<TextEdit>?;
+
 /// Result for a request to resolve project-wide references for the symbol
 /// denoted by the given text document position. The request's parameter is of
 /// type [ReferenceParams] the response is of type
@@ -303,8 +321,8 @@ typedef TextDocumentSignatureHelpResult = SignatureHelp?;
 
 /// Result for a request to resolve the type definition locations of a symbol at
 /// a given text document position. The request's parameter is of type
-/// [TextDocumentPositionParams] the response is of type [Definition] or a
-/// [Future] that resolves to such.
+/// [TextDocumentPositionParams]
+/// the response is of type [Definition] or a [Future] that resolves to such.
 typedef TextDocumentTypeDefinitionResult
     = Either2<Definition, List<DefinitionLink>>?;
 
@@ -5950,7 +5968,7 @@ class CompletionParams
     );
   }
 
-  /// The completion context. This is only available it the client specifies to
+  /// The completion context. This is only available if the client specifies to
   /// send this using the client capability
   /// `textDocument.completion.contextSupport === true`
   final CompletionContext? context;
@@ -6271,7 +6289,9 @@ class ConfigurationItem implements ToJsonable {
   });
   static ConfigurationItem fromJson(Map<String, Object?> json) {
     final scopeUriJson = json['scopeUri'];
-    final scopeUri = scopeUriJson as String?;
+    final scopeUri = scopeUriJson != null
+        ? Uri.parse(Uri.decodeFull(scopeUriJson as String))
+        : null;
     final sectionJson = json['section'];
     final section = sectionJson as String?;
     return ConfigurationItem(
@@ -6281,7 +6301,7 @@ class ConfigurationItem implements ToJsonable {
   }
 
   /// The scope to get the configuration section for.
-  final String? scopeUri;
+  final LSPUri? scopeUri;
 
   /// The configuration section asked for.
   final String? section;
@@ -6290,7 +6310,7 @@ class ConfigurationItem implements ToJsonable {
   Map<String, Object?> toJson() {
     var result = <String, Object?>{};
     if (scopeUri != null) {
-      result['scopeUri'] = scopeUri;
+      result['scopeUri'] = scopeUri?.toString();
     }
     if (section != null) {
       result['section'] = section;
@@ -6300,7 +6320,7 @@ class ConfigurationItem implements ToJsonable {
 
   static bool canParse(Object? obj, LspJsonReporter reporter) {
     if (obj is Map<String, Object?>) {
-      if (!_canParseString(obj, reporter, 'scopeUri',
+      if (!_canParseUri(obj, reporter, 'scopeUri',
           allowsUndefined: true, allowsNull: false)) {
         return false;
       }
@@ -11300,18 +11320,28 @@ class DocumentRangeFormattingClientCapabilities implements ToJsonable {
 
   DocumentRangeFormattingClientCapabilities({
     this.dynamicRegistration,
+    this.rangesSupport,
   });
   static DocumentRangeFormattingClientCapabilities fromJson(
       Map<String, Object?> json) {
     final dynamicRegistrationJson = json['dynamicRegistration'];
     final dynamicRegistration = dynamicRegistrationJson as bool?;
+    final rangesSupportJson = json['rangesSupport'];
+    final rangesSupport = rangesSupportJson as bool?;
     return DocumentRangeFormattingClientCapabilities(
       dynamicRegistration: dynamicRegistration,
+      rangesSupport: rangesSupport,
     );
   }
 
   /// Whether range formatting supports dynamic registration.
   final bool? dynamicRegistration;
+
+  /// Whether the client supports formatting multiple ranges at once.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final bool? rangesSupport;
 
   @override
   Map<String, Object?> toJson() {
@@ -11319,12 +11349,19 @@ class DocumentRangeFormattingClientCapabilities implements ToJsonable {
     if (dynamicRegistration != null) {
       result['dynamicRegistration'] = dynamicRegistration;
     }
+    if (rangesSupport != null) {
+      result['rangesSupport'] = rangesSupport;
+    }
     return result;
   }
 
   static bool canParse(Object? obj, LspJsonReporter reporter) {
     if (obj is Map<String, Object?>) {
-      return _canParseBool(obj, reporter, 'dynamicRegistration',
+      if (!_canParseBool(obj, reporter, 'dynamicRegistration',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
+      return _canParseBool(obj, reporter, 'rangesSupport',
           allowsUndefined: true, allowsNull: false);
     } else {
       reporter.reportError(
@@ -11337,11 +11374,15 @@ class DocumentRangeFormattingClientCapabilities implements ToJsonable {
   bool operator ==(Object other) {
     return other is DocumentRangeFormattingClientCapabilities &&
         other.runtimeType == DocumentRangeFormattingClientCapabilities &&
-        dynamicRegistration == other.dynamicRegistration;
+        dynamicRegistration == other.dynamicRegistration &&
+        rangesSupport == other.rangesSupport;
   }
 
   @override
-  int get hashCode => dynamicRegistration.hashCode;
+  int get hashCode => Object.hash(
+        dynamicRegistration,
+        rangesSupport,
+      );
 
   @override
   String toString() => jsonEncoder.convert(toJson());
@@ -11356,6 +11397,7 @@ class DocumentRangeFormattingOptions
   );
 
   DocumentRangeFormattingOptions({
+    this.rangesSupport,
     this.workDoneProgress,
   });
   static DocumentRangeFormattingOptions fromJson(Map<String, Object?> json) {
@@ -11363,19 +11405,30 @@ class DocumentRangeFormattingOptions
         json, nullLspJsonReporter)) {
       return DocumentRangeFormattingRegistrationOptions.fromJson(json);
     }
+    final rangesSupportJson = json['rangesSupport'];
+    final rangesSupport = rangesSupportJson as bool?;
     final workDoneProgressJson = json['workDoneProgress'];
     final workDoneProgress = workDoneProgressJson as bool?;
     return DocumentRangeFormattingOptions(
+      rangesSupport: rangesSupport,
       workDoneProgress: workDoneProgress,
     );
   }
 
+  /// Whether the server supports formatting multiple ranges at once.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final bool? rangesSupport;
   @override
   final bool? workDoneProgress;
 
   @override
   Map<String, Object?> toJson() {
     var result = <String, Object?>{};
+    if (rangesSupport != null) {
+      result['rangesSupport'] = rangesSupport;
+    }
     if (workDoneProgress != null) {
       result['workDoneProgress'] = workDoneProgress;
     }
@@ -11384,6 +11437,10 @@ class DocumentRangeFormattingOptions
 
   static bool canParse(Object? obj, LspJsonReporter reporter) {
     if (obj is Map<String, Object?>) {
+      if (!_canParseBool(obj, reporter, 'rangesSupport',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
       return _canParseBool(obj, reporter, 'workDoneProgress',
           allowsUndefined: true, allowsNull: false);
     } else {
@@ -11396,11 +11453,15 @@ class DocumentRangeFormattingOptions
   bool operator ==(Object other) {
     return other is DocumentRangeFormattingOptions &&
         other.runtimeType == DocumentRangeFormattingOptions &&
+        rangesSupport == other.rangesSupport &&
         workDoneProgress == other.workDoneProgress;
   }
 
   @override
-  int get hashCode => workDoneProgress.hashCode;
+  int get hashCode => Object.hash(
+        rangesSupport,
+        workDoneProgress,
+      );
 
   @override
   String toString() => jsonEncoder.convert(toJson());
@@ -11522,6 +11583,7 @@ class DocumentRangeFormattingRegistrationOptions
 
   DocumentRangeFormattingRegistrationOptions({
     this.documentSelector,
+    this.rangesSupport,
     this.workDoneProgress,
   });
   static DocumentRangeFormattingRegistrationOptions fromJson(
@@ -11531,10 +11593,13 @@ class DocumentRangeFormattingRegistrationOptions
         ?.map((item) =>
             TextDocumentFilterWithScheme.fromJson(item as Map<String, Object?>))
         .toList();
+    final rangesSupportJson = json['rangesSupport'];
+    final rangesSupport = rangesSupportJson as bool?;
     final workDoneProgressJson = json['workDoneProgress'];
     final workDoneProgress = workDoneProgressJson as bool?;
     return DocumentRangeFormattingRegistrationOptions(
       documentSelector: documentSelector,
+      rangesSupport: rangesSupport,
       workDoneProgress: workDoneProgress,
     );
   }
@@ -11543,6 +11608,13 @@ class DocumentRangeFormattingRegistrationOptions
   /// null the document selector provided on the client side will be used.
   @override
   final List<TextDocumentFilterWithScheme>? documentSelector;
+
+  /// Whether the server supports formatting multiple ranges at once.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  @override
+  final bool? rangesSupport;
   @override
   final bool? workDoneProgress;
 
@@ -11550,6 +11622,9 @@ class DocumentRangeFormattingRegistrationOptions
   Map<String, Object?> toJson() {
     var result = <String, Object?>{};
     result['documentSelector'] = documentSelector;
+    if (rangesSupport != null) {
+      result['rangesSupport'] = rangesSupport;
+    }
     if (workDoneProgress != null) {
       result['workDoneProgress'] = workDoneProgress;
     }
@@ -11561,6 +11636,10 @@ class DocumentRangeFormattingRegistrationOptions
       if (!_canParseListTextDocumentFilterWithScheme(
           obj, reporter, 'documentSelector',
           allowsUndefined: false, allowsNull: true)) {
+        return false;
+      }
+      if (!_canParseBool(obj, reporter, 'rangesSupport',
+          allowsUndefined: true, allowsNull: false)) {
         return false;
       }
       return _canParseBool(obj, reporter, 'workDoneProgress',
@@ -11581,13 +11660,123 @@ class DocumentRangeFormattingRegistrationOptions
             other.documentSelector,
             (TextDocumentFilterWithScheme a, TextDocumentFilterWithScheme b) =>
                 a == b) &&
+        rangesSupport == other.rangesSupport &&
         workDoneProgress == other.workDoneProgress;
   }
 
   @override
   int get hashCode => Object.hash(
         lspHashCode(documentSelector),
+        rangesSupport,
         workDoneProgress,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// The parameters of a [DocumentRangesFormattingRequest].
+///
+/// @since 3.18.0
+/// @proposed
+class DocumentRangesFormattingParams
+    implements WorkDoneProgressParams, ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    DocumentRangesFormattingParams.canParse,
+    DocumentRangesFormattingParams.fromJson,
+  );
+
+  DocumentRangesFormattingParams({
+    required this.options,
+    required this.ranges,
+    required this.textDocument,
+    this.workDoneToken,
+  });
+  static DocumentRangesFormattingParams fromJson(Map<String, Object?> json) {
+    final optionsJson = json['options'];
+    final options =
+        FormattingOptions.fromJson(optionsJson as Map<String, Object?>);
+    final rangesJson = json['ranges'];
+    final ranges = (rangesJson as List<Object?>)
+        .map((item) => Range.fromJson(item as Map<String, Object?>))
+        .toList();
+    final textDocumentJson = json['textDocument'];
+    final textDocument = TextDocumentIdentifier.fromJson(
+        textDocumentJson as Map<String, Object?>);
+    final workDoneTokenJson = json['workDoneToken'];
+    final workDoneToken =
+        workDoneTokenJson == null ? null : _eitherIntString(workDoneTokenJson);
+    return DocumentRangesFormattingParams(
+      options: options,
+      ranges: ranges,
+      textDocument: textDocument,
+      workDoneToken: workDoneToken,
+    );
+  }
+
+  /// The format options
+  final FormattingOptions options;
+
+  /// The ranges to format
+  final List<Range> ranges;
+
+  /// The document to format.
+  final TextDocumentIdentifier textDocument;
+
+  /// An optional token that a server can use to report work done progress.
+  @override
+  final ProgressToken? workDoneToken;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['options'] = options.toJson();
+    result['ranges'] = ranges.map((item) => item.toJson()).toList();
+    result['textDocument'] = textDocument.toJson();
+    if (workDoneToken != null) {
+      result['workDoneToken'] = workDoneToken;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseFormattingOptions(obj, reporter, 'options',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParseListRange(obj, reporter, 'ranges',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParseTextDocumentIdentifier(obj, reporter, 'textDocument',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      return _canParseIntString(obj, reporter, 'workDoneToken',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type DocumentRangesFormattingParams');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DocumentRangesFormattingParams &&
+        other.runtimeType == DocumentRangesFormattingParams &&
+        options == other.options &&
+        listEqual(ranges, other.ranges, (Range a, Range b) => a == b) &&
+        textDocument == other.textDocument &&
+        workDoneToken == other.workDoneToken;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        options,
+        lspHashCode(ranges),
+        textDocument,
+        workDoneToken,
       );
 
   @override
@@ -12329,7 +12518,7 @@ class ErrorCodes implements ToJsonable {
   static const MethodNotFound = ErrorCodes(-32601);
   static const ParseError = ErrorCodes(-32700);
 
-  /// The client has canceled a request and a server as detected the cancel.
+  /// The client has canceled a request and a server has detected the cancel.
   static const RequestCancelled = ErrorCodes(-32800);
 
   /// A request failed but it was syntactically correct, e.g the method name was
@@ -13407,7 +13596,7 @@ class FileOperationPattern implements ToJsonable {
   }
 
   /// The glob pattern to match. Glob patterns can have the following syntax:
-  /// - `*` to match one or more characters in a path segment
+  /// - `*` to match zero or more characters in a path segment
   /// - `?` to match on one character in a path segment
   /// - `**` to match any number of path segments, including none
   /// - `{}` to group sub patterns into an OR expression. (e.g. `**​/*.{ts,js}`
@@ -14447,6 +14636,74 @@ class FoldingRangeRegistrationOptions
         id,
         workDoneProgress,
       );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Client workspace capabilities specific to folding ranges
+///
+/// @since 3.18.0
+/// @proposed
+class FoldingRangeWorkspaceClientCapabilities implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    FoldingRangeWorkspaceClientCapabilities.canParse,
+    FoldingRangeWorkspaceClientCapabilities.fromJson,
+  );
+
+  FoldingRangeWorkspaceClientCapabilities({
+    this.refreshSupport,
+  });
+  static FoldingRangeWorkspaceClientCapabilities fromJson(
+      Map<String, Object?> json) {
+    final refreshSupportJson = json['refreshSupport'];
+    final refreshSupport = refreshSupportJson as bool?;
+    return FoldingRangeWorkspaceClientCapabilities(
+      refreshSupport: refreshSupport,
+    );
+  }
+
+  /// Whether the client implementation supports a refresh request sent from the
+  /// server to the client.
+  ///
+  /// Note that this event is global and will force the client to refresh all
+  /// folding ranges currently shown. It should be used with absolute care and
+  /// is useful for situation where a server for example detects a project wide
+  /// change that requires such a calculation.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final bool? refreshSupport;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    if (refreshSupport != null) {
+      result['refreshSupport'] = refreshSupport;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      return _canParseBool(obj, reporter, 'refreshSupport',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter.reportError(
+          'must be of type FoldingRangeWorkspaceClientCapabilities');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FoldingRangeWorkspaceClientCapabilities &&
+        other.runtimeType == FoldingRangeWorkspaceClientCapabilities &&
+        refreshSupport == other.refreshSupport;
+  }
+
+  @override
+  int get hashCode => refreshSupport.hashCode;
 
   @override
   String toString() => jsonEncoder.convert(toJson());
@@ -16168,6 +16425,9 @@ class InlayHint implements ToJsonable {
   final bool? paddingRight;
 
   /// The position of this hint.
+  ///
+  /// If multiple hints have the same position, they will be shown in the order
+  /// they appear in the response.
   final Position position;
 
   /// Optional text edits that are performed when accepting this inlay hint.
@@ -16909,6 +17169,626 @@ class InlayHintWorkspaceClientCapabilities implements ToJsonable {
 
   @override
   String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Client capabilities specific to inline completions.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionClientCapabilities implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionClientCapabilities.canParse,
+    InlineCompletionClientCapabilities.fromJson,
+  );
+
+  InlineCompletionClientCapabilities({
+    this.dynamicRegistration,
+  });
+  static InlineCompletionClientCapabilities fromJson(
+      Map<String, Object?> json) {
+    final dynamicRegistrationJson = json['dynamicRegistration'];
+    final dynamicRegistration = dynamicRegistrationJson as bool?;
+    return InlineCompletionClientCapabilities(
+      dynamicRegistration: dynamicRegistration,
+    );
+  }
+
+  /// Whether implementation supports dynamic registration for inline completion
+  /// providers.
+  final bool? dynamicRegistration;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    if (dynamicRegistration != null) {
+      result['dynamicRegistration'] = dynamicRegistration;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      return _canParseBool(obj, reporter, 'dynamicRegistration',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter
+          .reportError('must be of type InlineCompletionClientCapabilities');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionClientCapabilities &&
+        other.runtimeType == InlineCompletionClientCapabilities &&
+        dynamicRegistration == other.dynamicRegistration;
+  }
+
+  @override
+  int get hashCode => dynamicRegistration.hashCode;
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Provides information about the context in which an inline completion was
+/// requested.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionContext implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionContext.canParse,
+    InlineCompletionContext.fromJson,
+  );
+
+  InlineCompletionContext({
+    this.selectedCompletionInfo,
+    required this.triggerKind,
+  });
+  static InlineCompletionContext fromJson(Map<String, Object?> json) {
+    final selectedCompletionInfoJson = json['selectedCompletionInfo'];
+    final selectedCompletionInfo = selectedCompletionInfoJson != null
+        ? SelectedCompletionInfo.fromJson(
+            selectedCompletionInfoJson as Map<String, Object?>)
+        : null;
+    final triggerKindJson = json['triggerKind'];
+    final triggerKind =
+        InlineCompletionTriggerKind.fromJson(triggerKindJson as int);
+    return InlineCompletionContext(
+      selectedCompletionInfo: selectedCompletionInfo,
+      triggerKind: triggerKind,
+    );
+  }
+
+  /// Provides information about the currently selected item in the autocomplete
+  /// widget if it is visible.
+  final SelectedCompletionInfo? selectedCompletionInfo;
+
+  /// Describes how the inline completion was triggered.
+  final InlineCompletionTriggerKind triggerKind;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    if (selectedCompletionInfo != null) {
+      result['selectedCompletionInfo'] = selectedCompletionInfo?.toJson();
+    }
+    result['triggerKind'] = triggerKind.toJson();
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseSelectedCompletionInfo(
+          obj, reporter, 'selectedCompletionInfo',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
+      return _canParseInlineCompletionTriggerKind(obj, reporter, 'triggerKind',
+          allowsUndefined: false, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type InlineCompletionContext');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionContext &&
+        other.runtimeType == InlineCompletionContext &&
+        selectedCompletionInfo == other.selectedCompletionInfo &&
+        triggerKind == other.triggerKind;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        selectedCompletionInfo,
+        triggerKind,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// An inline completion item represents a text snippet that is proposed inline
+/// to complete text that is being typed.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionItem implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionItem.canParse,
+    InlineCompletionItem.fromJson,
+  );
+
+  InlineCompletionItem({
+    this.command,
+    this.filterText,
+    required this.insertText,
+    this.range,
+  });
+  static InlineCompletionItem fromJson(Map<String, Object?> json) {
+    final commandJson = json['command'];
+    final command = commandJson != null
+        ? Command.fromJson(commandJson as Map<String, Object?>)
+        : null;
+    final filterTextJson = json['filterText'];
+    final filterText = filterTextJson as String?;
+    final insertTextJson = json['insertText'];
+    final insertText = _eitherStringStringValue(insertTextJson);
+    final rangeJson = json['range'];
+    final range = rangeJson != null
+        ? Range.fromJson(rangeJson as Map<String, Object?>)
+        : null;
+    return InlineCompletionItem(
+      command: command,
+      filterText: filterText,
+      insertText: insertText,
+      range: range,
+    );
+  }
+
+  /// An optional [Command] that is executed *after* inserting this completion.
+  final Command? command;
+
+  /// A text that is used to decide if this inline completion should be shown.
+  /// When `falsy` the [InlineCompletionItem.insertText] is used.
+  final String? filterText;
+
+  /// The text to replace the range with. Must be set.
+  final Either2<String, StringValue> insertText;
+
+  /// The range to replace. Must begin and end on the same line.
+  final Range? range;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    if (command != null) {
+      result['command'] = command?.toJson();
+    }
+    if (filterText != null) {
+      result['filterText'] = filterText;
+    }
+    result['insertText'] = insertText;
+    if (range != null) {
+      result['range'] = range?.toJson();
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseCommand(obj, reporter, 'command',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParseString(obj, reporter, 'filterText',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParseStringStringValue(obj, reporter, 'insertText',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      return _canParseRange(obj, reporter, 'range',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type InlineCompletionItem');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionItem &&
+        other.runtimeType == InlineCompletionItem &&
+        command == other.command &&
+        filterText == other.filterText &&
+        insertText == other.insertText &&
+        range == other.range;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        command,
+        filterText,
+        insertText,
+        range,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Represents a collection of [InlineCompletionItem] to be presented in the
+/// editor.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionList implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionList.canParse,
+    InlineCompletionList.fromJson,
+  );
+
+  InlineCompletionList({
+    required this.items,
+  });
+  static InlineCompletionList fromJson(Map<String, Object?> json) {
+    final itemsJson = json['items'];
+    final items = (itemsJson as List<Object?>)
+        .map((item) =>
+            InlineCompletionItem.fromJson(item as Map<String, Object?>))
+        .toList();
+    return InlineCompletionList(
+      items: items,
+    );
+  }
+
+  /// The inline completion items
+  final List<InlineCompletionItem> items;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['items'] = items.map((item) => item.toJson()).toList();
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      return _canParseListInlineCompletionItem(obj, reporter, 'items',
+          allowsUndefined: false, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type InlineCompletionList');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionList &&
+        other.runtimeType == InlineCompletionList &&
+        listEqual(items, other.items,
+            (InlineCompletionItem a, InlineCompletionItem b) => a == b);
+  }
+
+  @override
+  int get hashCode => lspHashCode(items);
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Inline completion options used during static registration.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionOptions implements WorkDoneProgressOptions, ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionOptions.canParse,
+    InlineCompletionOptions.fromJson,
+  );
+
+  InlineCompletionOptions({
+    this.workDoneProgress,
+  });
+  static InlineCompletionOptions fromJson(Map<String, Object?> json) {
+    if (InlineCompletionRegistrationOptions.canParse(
+        json, nullLspJsonReporter)) {
+      return InlineCompletionRegistrationOptions.fromJson(json);
+    }
+    final workDoneProgressJson = json['workDoneProgress'];
+    final workDoneProgress = workDoneProgressJson as bool?;
+    return InlineCompletionOptions(
+      workDoneProgress: workDoneProgress,
+    );
+  }
+
+  @override
+  final bool? workDoneProgress;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    if (workDoneProgress != null) {
+      result['workDoneProgress'] = workDoneProgress;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      return _canParseBool(obj, reporter, 'workDoneProgress',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type InlineCompletionOptions');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionOptions &&
+        other.runtimeType == InlineCompletionOptions &&
+        workDoneProgress == other.workDoneProgress;
+  }
+
+  @override
+  int get hashCode => workDoneProgress.hashCode;
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// A parameter literal used in inline completion requests.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionParams
+    implements TextDocumentPositionParams, WorkDoneProgressParams, ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionParams.canParse,
+    InlineCompletionParams.fromJson,
+  );
+
+  InlineCompletionParams({
+    required this.context,
+    required this.position,
+    required this.textDocument,
+    this.workDoneToken,
+  });
+  static InlineCompletionParams fromJson(Map<String, Object?> json) {
+    final contextJson = json['context'];
+    final context =
+        InlineCompletionContext.fromJson(contextJson as Map<String, Object?>);
+    final positionJson = json['position'];
+    final position = Position.fromJson(positionJson as Map<String, Object?>);
+    final textDocumentJson = json['textDocument'];
+    final textDocument = TextDocumentIdentifier.fromJson(
+        textDocumentJson as Map<String, Object?>);
+    final workDoneTokenJson = json['workDoneToken'];
+    final workDoneToken =
+        workDoneTokenJson == null ? null : _eitherIntString(workDoneTokenJson);
+    return InlineCompletionParams(
+      context: context,
+      position: position,
+      textDocument: textDocument,
+      workDoneToken: workDoneToken,
+    );
+  }
+
+  /// Additional information about the context in which inline completions were
+  /// requested.
+  final InlineCompletionContext context;
+
+  /// The position inside the text document.
+  @override
+  final Position position;
+
+  /// The text document.
+  @override
+  final TextDocumentIdentifier textDocument;
+
+  /// An optional token that a server can use to report work done progress.
+  @override
+  final ProgressToken? workDoneToken;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['context'] = context.toJson();
+    result['position'] = position.toJson();
+    result['textDocument'] = textDocument.toJson();
+    if (workDoneToken != null) {
+      result['workDoneToken'] = workDoneToken;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseInlineCompletionContext(obj, reporter, 'context',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParsePosition(obj, reporter, 'position',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      if (!_canParseTextDocumentIdentifier(obj, reporter, 'textDocument',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      return _canParseIntString(obj, reporter, 'workDoneToken',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type InlineCompletionParams');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionParams &&
+        other.runtimeType == InlineCompletionParams &&
+        context == other.context &&
+        position == other.position &&
+        textDocument == other.textDocument &&
+        workDoneToken == other.workDoneToken;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        context,
+        position,
+        textDocument,
+        workDoneToken,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Inline completion options used during static or dynamic registration.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionRegistrationOptions
+    implements
+        InlineCompletionOptions,
+        StaticRegistrationOptions,
+        TextDocumentRegistrationOptions,
+        ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    InlineCompletionRegistrationOptions.canParse,
+    InlineCompletionRegistrationOptions.fromJson,
+  );
+
+  InlineCompletionRegistrationOptions({
+    this.documentSelector,
+    this.id,
+    this.workDoneProgress,
+  });
+  static InlineCompletionRegistrationOptions fromJson(
+      Map<String, Object?> json) {
+    final documentSelectorJson = json['documentSelector'];
+    final documentSelector = (documentSelectorJson as List<Object?>?)
+        ?.map((item) =>
+            TextDocumentFilterWithScheme.fromJson(item as Map<String, Object?>))
+        .toList();
+    final idJson = json['id'];
+    final id = idJson as String?;
+    final workDoneProgressJson = json['workDoneProgress'];
+    final workDoneProgress = workDoneProgressJson as bool?;
+    return InlineCompletionRegistrationOptions(
+      documentSelector: documentSelector,
+      id: id,
+      workDoneProgress: workDoneProgress,
+    );
+  }
+
+  /// A document selector to identify the scope of the registration. If set to
+  /// null the document selector provided on the client side will be used.
+  @override
+  final List<TextDocumentFilterWithScheme>? documentSelector;
+
+  /// The id used to register the request. The id can be used to deregister the
+  /// request again. See also Registration#id.
+  @override
+  final String? id;
+  @override
+  final bool? workDoneProgress;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['documentSelector'] = documentSelector;
+    if (id != null) {
+      result['id'] = id;
+    }
+    if (workDoneProgress != null) {
+      result['workDoneProgress'] = workDoneProgress;
+    }
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseListTextDocumentFilterWithScheme(
+          obj, reporter, 'documentSelector',
+          allowsUndefined: false, allowsNull: true)) {
+        return false;
+      }
+      if (!_canParseString(obj, reporter, 'id',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
+      return _canParseBool(obj, reporter, 'workDoneProgress',
+          allowsUndefined: true, allowsNull: false);
+    } else {
+      reporter
+          .reportError('must be of type InlineCompletionRegistrationOptions');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is InlineCompletionRegistrationOptions &&
+        other.runtimeType == InlineCompletionRegistrationOptions &&
+        listEqual(
+            documentSelector,
+            other.documentSelector,
+            (TextDocumentFilterWithScheme a, TextDocumentFilterWithScheme b) =>
+                a == b) &&
+        id == other.id &&
+        workDoneProgress == other.workDoneProgress;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        lspHashCode(documentSelector),
+        id,
+        workDoneProgress,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// Describes how an [InlineCompletionItemProvider] was triggered.
+///
+/// @since 3.18.0
+/// @proposed
+class InlineCompletionTriggerKind implements ToJsonable {
+  const InlineCompletionTriggerKind(this._value);
+  const InlineCompletionTriggerKind.fromJson(this._value);
+
+  final int _value;
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) => obj is int;
+
+  /// Completion was triggered automatically while editing.
+  static const Automatic = InlineCompletionTriggerKind(1);
+
+  /// Completion was triggered explicitly by a user gesture.
+  static const Invoked = InlineCompletionTriggerKind(0);
+
+  @override
+  Object toJson() => _value;
+
+  @override
+  String toString() => _value.toString();
+
+  @override
+  int get hashCode => _value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is InlineCompletionTriggerKind && other._value == _value;
 }
 
 /// Client capabilities specific to inline values.
@@ -17747,7 +18627,7 @@ class InsertTextMode implements ToJsonable {
   /// The editor adjusts leading whitespace of new lines so that they match the
   /// indentation up to the cursor of the line for which the item is accepted.
   ///
-  /// Consider a line like this: `<2tabs><cursor><3tabs>foo`. Accepting a multi
+  /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a multi
   /// line completion item is indented using 2 tabs and all following lines
   /// inserted will be indented using 2 tabs as well.
   static const adjustIndentation = InsertTextMode(2);
@@ -18754,6 +19634,11 @@ class MessageType implements ToJsonable {
 
   static bool canParse(Object? obj, LspJsonReporter reporter) => obj is int;
 
+  /// A debug message.
+  ///
+  /// @since 3.18.0
+  static const Debug = MessageType(5);
+
   /// An error message.
   static const Error = MessageType(1);
 
@@ -18924,6 +19809,10 @@ class Method implements ToJsonable {
   /// Constant for the 'textDocument/inlayHint' method.
   static const textDocument_inlayHint = Method('textDocument/inlayHint');
 
+  /// Constant for the 'textDocument/inlineCompletion' method.
+  static const textDocument_inlineCompletion =
+      Method('textDocument/inlineCompletion');
+
   /// Constant for the 'textDocument/inlineValue' method.
   static const textDocument_inlineValue = Method('textDocument/inlineValue');
 
@@ -18957,6 +19846,10 @@ class Method implements ToJsonable {
   /// Constant for the 'textDocument/rangeFormatting' method.
   static const textDocument_rangeFormatting =
       Method('textDocument/rangeFormatting');
+
+  /// Constant for the 'textDocument/rangesFormatting' method.
+  static const textDocument_rangesFormatting =
+      Method('textDocument/rangesFormatting');
 
   /// Constant for the 'textDocument/references' method.
   static const textDocument_references = Method('textDocument/references');
@@ -19061,6 +19954,10 @@ class Method implements ToJsonable {
 
   /// Constant for the 'workspace/executeCommand' method.
   static const workspace_executeCommand = Method('workspace/executeCommand');
+
+  /// Constant for the 'workspace/foldingRange/refresh' method.
+  static const workspace_foldingRange_refresh =
+      Method('workspace/foldingRange/refresh');
 
   /// Constant for the 'workspace/inlayHint/refresh' method.
   static const workspace_inlayHint_refresh =
@@ -21642,20 +22539,8 @@ class PlaceholderAndRange implements ToJsonable {
 /// offset of b is 3 since `𐐀` is represented using two code units in UTF-16.
 /// Since 3.17 clients and servers can agree on a different string encoding
 /// representation (e.g. UTF-8). The client announces it's supported encoding
-/// via the client capability [general.positionEncodings]. The value is an array
-/// of position encodings the client supports, with decreasing preference (e.g.
-/// the encoding at index `0` is the most preferred one). To stay backwards
-/// compatible the only mandatory encoding is UTF-16 represented via the string
-/// `utf-16`. The server can pick one of the encodings offered by the client and
-/// signals that encoding back to the client via the initialize result's
-/// property [capabilities.positionEncoding]. If the string value `utf-16` is
-/// missing from the client's capability `general.positionEncodings` servers can
-/// safely assume that the client supports UTF-16. If the server omits the
-/// position encoding in its initialize result the encoding defaults to the
-/// string value `utf-16`. Implementation considerations: since the conversion
-/// from one encoding into another requires the content of the file / line the
-/// conversion is best done where the file is read which is usually on the
-/// server side.
+/// via the client capability
+/// [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities). The value is an array of position encodings the client supports, with decreasing preference (e.g. the encoding at index `0` is the most preferred one). To stay backwards compatible the only mandatory encoding is UTF-16 represented via the string `utf-16`. The server can pick one of the encodings offered by the client and signals that encoding back to the client via the initialize result's property [`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value `utf-16` is missing from the client's capability `general.positionEncodings` servers can safely assume that the client supports UTF-16. If the server omits the position encoding in its initialize result the encoding defaults to the string value `utf-16`. Implementation considerations: since the conversion from one encoding into another requires the content of the file / line the conversion is best done where the file is read which is usually on the server side.
 ///
 /// Positions are line end character agnostic. So you can not specify a position
 /// that denotes `\r|\n` or `\n|` where `|` represents the character offset.
@@ -24184,6 +25069,77 @@ class SaveOptions implements ToJsonable {
   String toString() => jsonEncoder.convert(toJson());
 }
 
+/// Describes the currently selected completion item.
+///
+/// @since 3.18.0
+/// @proposed
+class SelectedCompletionInfo implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    SelectedCompletionInfo.canParse,
+    SelectedCompletionInfo.fromJson,
+  );
+
+  SelectedCompletionInfo({
+    required this.range,
+    required this.text,
+  });
+  static SelectedCompletionInfo fromJson(Map<String, Object?> json) {
+    final rangeJson = json['range'];
+    final range = Range.fromJson(rangeJson as Map<String, Object?>);
+    final textJson = json['text'];
+    final text = textJson as String;
+    return SelectedCompletionInfo(
+      range: range,
+      text: text,
+    );
+  }
+
+  /// The range that will be replaced if this completion item is accepted.
+  final Range range;
+
+  /// The text the range will be replaced with if this completion is accepted.
+  final String text;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['range'] = range.toJson();
+    result['text'] = text;
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseRange(obj, reporter, 'range',
+          allowsUndefined: false, allowsNull: false)) {
+        return false;
+      }
+      return _canParseString(obj, reporter, 'text',
+          allowsUndefined: false, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type SelectedCompletionInfo');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SelectedCompletionInfo &&
+        other.runtimeType == SelectedCompletionInfo &&
+        range == other.range &&
+        text == other.text;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        range,
+        text,
+      );
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
 /// A selection range represents a part of a selection hierarchy. A selection
 /// range may have a parent selection range that contains it.
 class SelectionRange implements ToJsonable {
@@ -26220,6 +27176,7 @@ class ServerCapabilities implements ToJsonable {
     this.hoverProvider,
     this.implementationProvider,
     this.inlayHintProvider,
+    this.inlineCompletionProvider,
     this.inlineValueProvider,
     this.linkedEditingRangeProvider,
     this.monikerProvider,
@@ -26331,6 +27288,10 @@ class ServerCapabilities implements ToJsonable {
         ? null
         : _eitherBoolInlayHintOptionsInlayHintRegistrationOptions(
             inlayHintProviderJson);
+    final inlineCompletionProviderJson = json['inlineCompletionProvider'];
+    final inlineCompletionProvider = inlineCompletionProviderJson == null
+        ? null
+        : _eitherBoolInlineCompletionOptions(inlineCompletionProviderJson);
     final inlineValueProviderJson = json['inlineValueProvider'];
     final inlineValueProvider = inlineValueProviderJson == null
         ? null
@@ -26423,6 +27384,7 @@ class ServerCapabilities implements ToJsonable {
       hoverProvider: hoverProvider,
       implementationProvider: implementationProvider,
       inlayHintProvider: inlayHintProvider,
+      inlineCompletionProvider: inlineCompletionProvider,
       inlineValueProvider: inlineValueProvider,
       linkedEditingRangeProvider: linkedEditingRangeProvider,
       monikerProvider: monikerProvider,
@@ -26516,6 +27478,12 @@ class ServerCapabilities implements ToJsonable {
   /// @since 3.17.0
   final Either3<bool, InlayHintOptions, InlayHintRegistrationOptions>?
       inlayHintProvider;
+
+  /// Inline completion options used during static registration.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final Either2<bool, InlineCompletionOptions>? inlineCompletionProvider;
 
   /// The server provides inline values.
   ///
@@ -26660,6 +27628,9 @@ class ServerCapabilities implements ToJsonable {
     if (inlayHintProvider != null) {
       result['inlayHintProvider'] = inlayHintProvider;
     }
+    if (inlineCompletionProvider != null) {
+      result['inlineCompletionProvider'] = inlineCompletionProvider;
+    }
     if (inlineValueProvider != null) {
       result['inlineValueProvider'] = inlineValueProvider;
     }
@@ -26799,6 +27770,11 @@ class ServerCapabilities implements ToJsonable {
           allowsUndefined: true, allowsNull: false)) {
         return false;
       }
+      if (!_canParseBoolInlineCompletionOptions(
+          obj, reporter, 'inlineCompletionProvider',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
       if (!_canParseBoolInlineValueOptionsInlineValueRegistrationOptions(
           obj, reporter, 'inlineValueProvider',
           allowsUndefined: true, allowsNull: false)) {
@@ -26899,6 +27875,7 @@ class ServerCapabilities implements ToJsonable {
         hoverProvider == other.hoverProvider &&
         implementationProvider == other.implementationProvider &&
         inlayHintProvider == other.inlayHintProvider &&
+        inlineCompletionProvider == other.inlineCompletionProvider &&
         inlineValueProvider == other.inlineValueProvider &&
         linkedEditingRangeProvider == other.linkedEditingRangeProvider &&
         monikerProvider == other.monikerProvider &&
@@ -26938,6 +27915,7 @@ class ServerCapabilities implements ToJsonable {
         hoverProvider,
         implementationProvider,
         inlayHintProvider,
+        inlineCompletionProvider,
         inlineValueProvider,
         linkedEditingRangeProvider,
         monikerProvider,
@@ -28590,6 +29568,10 @@ class StaticRegistrationOptions implements ToJsonable {
     if (InlayHintRegistrationOptions.canParse(json, nullLspJsonReporter)) {
       return InlayHintRegistrationOptions.fromJson(json);
     }
+    if (InlineCompletionRegistrationOptions.canParse(
+        json, nullLspJsonReporter)) {
+      return InlineCompletionRegistrationOptions.fromJson(json);
+    }
     if (InlineValueRegistrationOptions.canParse(json, nullLspJsonReporter)) {
       return InlineValueRegistrationOptions.fromJson(json);
     }
@@ -28652,6 +29634,86 @@ class StaticRegistrationOptions implements ToJsonable {
 
   @override
   int get hashCode => id.hashCode;
+
+  @override
+  String toString() => jsonEncoder.convert(toJson());
+}
+
+/// A string value used as a snippet is a template which allows to insert text
+/// and to control the editor cursor when insertion happens.
+///
+/// A snippet can define tab stops and placeholders with `$1`, `$2` and
+/// `${3:foo}`. `$0` defines the final tab stop, it defaults to the end of the
+/// snippet. Variables are defined with `$name` and `${name:default value}`.
+///
+/// @since 3.18.0
+/// @proposed
+class StringValue implements ToJsonable {
+  static const jsonHandler = LspJsonHandler(
+    StringValue.canParse,
+    StringValue.fromJson,
+  );
+
+  StringValue({
+    this.kind = 'snippet',
+    required this.value,
+  }) {
+    if (kind != 'snippet') {
+      throw 'kind may only be the literal \'snippet\'';
+    }
+  }
+  static StringValue fromJson(Map<String, Object?> json) {
+    final kindJson = json['kind'];
+    final kind = kindJson as String;
+    final valueJson = json['value'];
+    final value = valueJson as String;
+    return StringValue(
+      kind: kind,
+      value: value,
+    );
+  }
+
+  /// The kind of string value.
+  final String kind;
+
+  /// The snippet string.
+  final String value;
+
+  @override
+  Map<String, Object?> toJson() {
+    var result = <String, Object?>{};
+    result['kind'] = kind;
+    result['value'] = value;
+    return result;
+  }
+
+  static bool canParse(Object? obj, LspJsonReporter reporter) {
+    if (obj is Map<String, Object?>) {
+      if (!_canParseLiteral(obj, reporter, 'kind',
+          allowsUndefined: false, allowsNull: false, literal: 'snippet')) {
+        return false;
+      }
+      return _canParseString(obj, reporter, 'value',
+          allowsUndefined: false, allowsNull: false);
+    } else {
+      reporter.reportError('must be of type StringValue');
+      return false;
+    }
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is StringValue &&
+        other.runtimeType == StringValue &&
+        kind == other.kind &&
+        value == other.value;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        kind,
+        value,
+      );
 
   @override
   String toString() => jsonEncoder.convert(toJson());
@@ -28991,6 +30053,7 @@ class TextDocumentClientCapabilities implements ToJsonable {
     this.hover,
     this.implementation,
     this.inlayHint,
+    this.inlineCompletion,
     this.inlineValue,
     this.linkedEditingRange,
     this.moniker,
@@ -29086,6 +30149,11 @@ class TextDocumentClientCapabilities implements ToJsonable {
         ? InlayHintClientCapabilities.fromJson(
             inlayHintJson as Map<String, Object?>)
         : null;
+    final inlineCompletionJson = json['inlineCompletion'];
+    final inlineCompletion = inlineCompletionJson != null
+        ? InlineCompletionClientCapabilities.fromJson(
+            inlineCompletionJson as Map<String, Object?>)
+        : null;
     final inlineValueJson = json['inlineValue'];
     final inlineValue = inlineValueJson != null
         ? InlineValueClientCapabilities.fromJson(
@@ -29172,6 +30240,7 @@ class TextDocumentClientCapabilities implements ToJsonable {
       hover: hover,
       implementation: implementation,
       inlayHint: inlayHint,
+      inlineCompletion: inlineCompletion,
       inlineValue: inlineValue,
       linkedEditingRange: linkedEditingRange,
       moniker: moniker,
@@ -29251,6 +30320,12 @@ class TextDocumentClientCapabilities implements ToJsonable {
   ///
   /// @since 3.17.0
   final InlayHintClientCapabilities? inlayHint;
+
+  /// Client capabilities specific to inline completions.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final InlineCompletionClientCapabilities? inlineCompletion;
 
   /// Capabilities specific to the `textDocument/inlineValue` request.
   ///
@@ -29359,6 +30434,9 @@ class TextDocumentClientCapabilities implements ToJsonable {
     }
     if (inlayHint != null) {
       result['inlayHint'] = inlayHint?.toJson();
+    }
+    if (inlineCompletion != null) {
+      result['inlineCompletion'] = inlineCompletion?.toJson();
     }
     if (inlineValue != null) {
       result['inlineValue'] = inlineValue?.toJson();
@@ -29479,6 +30557,11 @@ class TextDocumentClientCapabilities implements ToJsonable {
           allowsUndefined: true, allowsNull: false)) {
         return false;
       }
+      if (!_canParseInlineCompletionClientCapabilities(
+          obj, reporter, 'inlineCompletion',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
       if (!_canParseInlineValueClientCapabilities(obj, reporter, 'inlineValue',
           allowsUndefined: true, allowsNull: false)) {
         return false;
@@ -29569,6 +30652,7 @@ class TextDocumentClientCapabilities implements ToJsonable {
         hover == other.hover &&
         implementation == other.implementation &&
         inlayHint == other.inlayHint &&
+        inlineCompletion == other.inlineCompletion &&
         inlineValue == other.inlineValue &&
         linkedEditingRange == other.linkedEditingRange &&
         moniker == other.moniker &&
@@ -29603,6 +30687,7 @@ class TextDocumentClientCapabilities implements ToJsonable {
         hover,
         implementation,
         inlayHint,
+        inlineCompletion,
         inlineValue,
         linkedEditingRange,
         moniker,
@@ -29872,7 +30957,7 @@ class TextDocumentFilter1 implements ToJsonable {
   /// A language id, like `typescript`.
   final String language;
 
-  /// A glob pattern, like `*.{ts,js}`.
+  /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
   final String? pattern;
 
   /// A Uri [Uri.scheme], like `file` or `untitled`.
@@ -29957,7 +31042,7 @@ class TextDocumentFilter3 implements ToJsonable {
   /// A language id, like `typescript`.
   final String? language;
 
-  /// A glob pattern, like `*.{ts,js}`.
+  /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
   final String pattern;
 
   /// A Uri [Uri.scheme], like `file` or `untitled`.
@@ -30042,7 +31127,7 @@ class TextDocumentFilterWithScheme implements ToJsonable {
   /// A language id, like `typescript`.
   final String? language;
 
-  /// A glob pattern, like `*.{ts,js}`.
+  /// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
   final String? pattern;
 
   /// A Uri [Uri.scheme], like `file` or `untitled`.
@@ -30268,6 +31353,9 @@ class TextDocumentPositionParams implements ToJsonable {
     required this.textDocument,
   });
   static TextDocumentPositionParams fromJson(Map<String, Object?> json) {
+    if (InlineCompletionParams.canParse(json, nullLspJsonReporter)) {
+      return InlineCompletionParams.fromJson(json);
+    }
     if (ReferenceParams.canParse(json, nullLspJsonReporter)) {
       return ReferenceParams.fromJson(json);
     }
@@ -30439,6 +31527,10 @@ class TextDocumentRegistrationOptions implements ToJsonable {
     }
     if (InlayHintRegistrationOptions.canParse(json, nullLspJsonReporter)) {
       return InlayHintRegistrationOptions.fromJson(json);
+    }
+    if (InlineCompletionRegistrationOptions.canParse(
+        json, nullLspJsonReporter)) {
+      return InlineCompletionRegistrationOptions.fromJson(json);
     }
     if (InlineValueRegistrationOptions.canParse(json, nullLspJsonReporter)) {
       return InlineValueRegistrationOptions.fromJson(json);
@@ -32711,7 +33803,7 @@ class WorkDoneProgressBegin implements ToJsonable {
 
   /// Optional progress percentage to display (value 100 is considered 100%). If
   /// not provided infinite progress is assumed and clients are allowed to
-  /// ignore the `percentage` value in subsequent in report notifications.
+  /// ignore the `percentage` value in subsequent report notifications.
   ///
   /// The value should be steadily rising. Clients are free to ignore values
   /// that are not following this rule. The value range is [0, 100].
@@ -32999,6 +34091,9 @@ class WorkDoneProgressOptions implements ToJsonable {
     if (DocumentLinkOptions.canParse(json, nullLspJsonReporter)) {
       return DocumentLinkOptions.fromJson(json);
     }
+    if (DocumentRangeFormattingOptions.canParse(json, nullLspJsonReporter)) {
+      return DocumentRangeFormattingOptions.fromJson(json);
+    }
     if (DocumentSymbolOptions.canParse(json, nullLspJsonReporter)) {
       return DocumentSymbolOptions.fromJson(json);
     }
@@ -33029,9 +34124,6 @@ class WorkDoneProgressOptions implements ToJsonable {
     if (DocumentHighlightOptions.canParse(json, nullLspJsonReporter)) {
       return DocumentHighlightOptions.fromJson(json);
     }
-    if (DocumentRangeFormattingOptions.canParse(json, nullLspJsonReporter)) {
-      return DocumentRangeFormattingOptions.fromJson(json);
-    }
     if (FoldingRangeOptions.canParse(json, nullLspJsonReporter)) {
       return FoldingRangeOptions.fromJson(json);
     }
@@ -33040,6 +34132,9 @@ class WorkDoneProgressOptions implements ToJsonable {
     }
     if (ImplementationOptions.canParse(json, nullLspJsonReporter)) {
       return ImplementationOptions.fromJson(json);
+    }
+    if (InlineCompletionOptions.canParse(json, nullLspJsonReporter)) {
+      return InlineCompletionOptions.fromJson(json);
     }
     if (InlineValueOptions.canParse(json, nullLspJsonReporter)) {
       return InlineValueOptions.fromJson(json);
@@ -33123,6 +34218,9 @@ class WorkDoneProgressParams implements ToJsonable {
     if (DocumentRangeFormattingParams.canParse(json, nullLspJsonReporter)) {
       return DocumentRangeFormattingParams.fromJson(json);
     }
+    if (DocumentRangesFormattingParams.canParse(json, nullLspJsonReporter)) {
+      return DocumentRangesFormattingParams.fromJson(json);
+    }
     if (InlineValueParams.canParse(json, nullLspJsonReporter)) {
       return InlineValueParams.fromJson(json);
     }
@@ -33176,6 +34274,9 @@ class WorkDoneProgressParams implements ToJsonable {
     }
     if (FoldingRangeParams.canParse(json, nullLspJsonReporter)) {
       return FoldingRangeParams.fromJson(json);
+    }
+    if (InlineCompletionParams.canParse(json, nullLspJsonReporter)) {
+      return InlineCompletionParams.fromJson(json);
     }
     if (ReferenceParams.canParse(json, nullLspJsonReporter)) {
       return ReferenceParams.fromJson(json);
@@ -33324,10 +34425,10 @@ class WorkDoneProgressReport implements ToJsonable {
 
   /// Optional progress percentage to display (value 100 is considered 100%). If
   /// not provided infinite progress is assumed and clients are allowed to
-  /// ignore the `percentage` value in subsequent in report notifications.
+  /// ignore the `percentage` value in subsequent report notifications.
   ///
   /// The value should be steadily rising. Clients are free to ignore values
-  /// that are not following this rule. The value range is [0, 100]
+  /// that are not following this rule. The value range is [0, 100].
   final int? percentage;
 
   @override
@@ -33406,6 +34507,7 @@ class WorkspaceClientCapabilities implements ToJsonable {
     this.didChangeWatchedFiles,
     this.executeCommand,
     this.fileOperations,
+    this.foldingRange,
     this.inlayHint,
     this.inlineValue,
     this.semanticTokens,
@@ -33448,6 +34550,11 @@ class WorkspaceClientCapabilities implements ToJsonable {
         ? FileOperationClientCapabilities.fromJson(
             fileOperationsJson as Map<String, Object?>)
         : null;
+    final foldingRangeJson = json['foldingRange'];
+    final foldingRange = foldingRangeJson != null
+        ? FoldingRangeWorkspaceClientCapabilities.fromJson(
+            foldingRangeJson as Map<String, Object?>)
+        : null;
     final inlayHintJson = json['inlayHint'];
     final inlayHint = inlayHintJson != null
         ? InlayHintWorkspaceClientCapabilities.fromJson(
@@ -33484,6 +34591,7 @@ class WorkspaceClientCapabilities implements ToJsonable {
       didChangeWatchedFiles: didChangeWatchedFiles,
       executeCommand: executeCommand,
       fileOperations: fileOperations,
+      foldingRange: foldingRange,
       inlayHint: inlayHint,
       inlineValue: inlineValue,
       semanticTokens: semanticTokens,
@@ -33529,6 +34637,13 @@ class WorkspaceClientCapabilities implements ToJsonable {
   ///
   /// Since 3.16.0
   final FileOperationClientCapabilities? fileOperations;
+
+  /// Capabilities specific to the folding range requests scoped to the
+  /// workspace.
+  ///
+  /// @since 3.18.0
+  /// @proposed
+  final FoldingRangeWorkspaceClientCapabilities? foldingRange;
 
   /// Capabilities specific to the inlay hint requests scoped to the workspace.
   ///
@@ -33584,6 +34699,9 @@ class WorkspaceClientCapabilities implements ToJsonable {
     }
     if (fileOperations != null) {
       result['fileOperations'] = fileOperations?.toJson();
+    }
+    if (foldingRange != null) {
+      result['foldingRange'] = foldingRange?.toJson();
     }
     if (inlayHint != null) {
       result['inlayHint'] = inlayHint?.toJson();
@@ -33646,6 +34764,11 @@ class WorkspaceClientCapabilities implements ToJsonable {
           allowsUndefined: true, allowsNull: false)) {
         return false;
       }
+      if (!_canParseFoldingRangeWorkspaceClientCapabilities(
+          obj, reporter, 'foldingRange',
+          allowsUndefined: true, allowsNull: false)) {
+        return false;
+      }
       if (!_canParseInlayHintWorkspaceClientCapabilities(
           obj, reporter, 'inlayHint',
           allowsUndefined: true, allowsNull: false)) {
@@ -33690,6 +34813,7 @@ class WorkspaceClientCapabilities implements ToJsonable {
         didChangeWatchedFiles == other.didChangeWatchedFiles &&
         executeCommand == other.executeCommand &&
         fileOperations == other.fileOperations &&
+        foldingRange == other.foldingRange &&
         inlayHint == other.inlayHint &&
         inlineValue == other.inlineValue &&
         semanticTokens == other.semanticTokens &&
@@ -33708,6 +34832,7 @@ class WorkspaceClientCapabilities implements ToJsonable {
         didChangeWatchedFiles,
         executeCommand,
         fileOperations,
+        foldingRange,
         inlayHint,
         inlineValue,
         semanticTokens,
@@ -35898,6 +37023,34 @@ bool _canParseBoolInlayHintOptionsInlayHintRegistrationOptions(
             !InlayHintRegistrationOptions.canParse(value, reporter))) {
       reporter.reportError(
           'must be of type Either3<bool, InlayHintOptions, InlayHintRegistrationOptions>');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseBoolInlineCompletionOptions(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        (value is! bool &&
+            !InlineCompletionOptions.canParse(value, reporter))) {
+      reporter.reportError(
+          'must be of type Either2<bool, InlineCompletionOptions>');
       return false;
     }
   } finally {
@@ -38169,6 +39322,33 @@ bool _canParseFoldingRangeKind(
   return true;
 }
 
+bool _canParseFoldingRangeWorkspaceClientCapabilities(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        !FoldingRangeWorkspaceClientCapabilities.canParse(value, reporter)) {
+      reporter.reportError(
+          'must be of type FoldingRangeWorkspaceClientCapabilities');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
 bool _canParseFormattingOptions(
     Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
     {required bool allowsUndefined, required bool allowsNull}) {
@@ -38451,6 +39631,85 @@ bool _canParseInlayHintWorkspaceClientCapabilities(
         !InlayHintWorkspaceClientCapabilities.canParse(value, reporter)) {
       reporter
           .reportError('must be of type InlayHintWorkspaceClientCapabilities');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseInlineCompletionClientCapabilities(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        !InlineCompletionClientCapabilities.canParse(value, reporter)) {
+      reporter
+          .reportError('must be of type InlineCompletionClientCapabilities');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseInlineCompletionContext(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        !InlineCompletionContext.canParse(value, reporter)) {
+      reporter.reportError('must be of type InlineCompletionContext');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseInlineCompletionTriggerKind(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        !InlineCompletionTriggerKind.canParse(value, reporter)) {
+      reporter.reportError('must be of type InlineCompletionTriggerKind');
       return false;
     }
   } finally {
@@ -39215,6 +40474,34 @@ bool _canParseListInlayHintLabelPartString(
                 value is! String)) {
       reporter.reportError(
           'must be of type Either2<List<InlayHintLabelPart>, String>');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseListInlineCompletionItem(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        (value is! List<Object?> ||
+            value.any(
+                (item) => !InlineCompletionItem.canParse(item, reporter)))) {
+      reporter.reportError('must be of type List<InlineCompletionItem>');
       return false;
     }
   } finally {
@@ -41086,6 +42373,32 @@ bool _canParseRenameFileOptions(
   return true;
 }
 
+bool _canParseSelectedCompletionInfo(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        !SelectedCompletionInfo.canParse(value, reporter)) {
+      reporter.reportError('must be of type SelectedCompletionInfo');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
 bool _canParseSelectionRange(
     Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
     {required bool allowsUndefined, required bool allowsNull}) {
@@ -41634,6 +42947,32 @@ bool _canParseStringRelativePattern(
         (value is! String && !RelativePattern.canParse(value, reporter))) {
       reporter
           .reportError('must be of type Either2<LspPattern, RelativePattern>');
+      return false;
+    }
+  } finally {
+    reporter.pop();
+  }
+  return true;
+}
+
+bool _canParseStringStringValue(
+    Map<String, Object?> map, LspJsonReporter reporter, String fieldName,
+    {required bool allowsUndefined, required bool allowsNull}) {
+  reporter.push(fieldName);
+  try {
+    if (!allowsUndefined && !map.containsKey(fieldName)) {
+      reporter.reportError('must not be undefined');
+      return false;
+    }
+    final value = map[fieldName];
+    final nullCheck = allowsNull || allowsUndefined;
+    if (!nullCheck && value == null) {
+      reporter.reportError('must not be null');
+      return false;
+    }
+    if ((!nullCheck || value != null) &&
+        (value is! String && !StringValue.canParse(value, reporter))) {
+      reporter.reportError('must be of type Either2<String, StringValue>');
       return false;
     }
   } finally {
@@ -42621,6 +43960,16 @@ Either3<bool, InlayHintOptions, InlayHintRegistrationOptions>
               : throw '$value was not one of (bool, InlayHintOptions, InlayHintRegistrationOptions)';
 }
 
+Either2<bool, InlineCompletionOptions> _eitherBoolInlineCompletionOptions(
+    Object? value) {
+  return value is bool
+      ? Either2.t1(value)
+      : InlineCompletionOptions.canParse(value, nullLspJsonReporter)
+          ? Either2.t2(
+              InlineCompletionOptions.fromJson(value as Map<String, Object?>))
+          : throw '$value was not one of (bool, InlineCompletionOptions)';
+}
+
 Either3<bool, InlineValueOptions, InlineValueRegistrationOptions>
     _eitherBoolInlineValueOptionsInlineValueRegistrationOptions(Object? value) {
   return value is bool
@@ -42962,6 +44311,14 @@ Either2<LspPattern, RelativePattern> _eitherStringRelativePattern(
       : RelativePattern.canParse(value, nullLspJsonReporter)
           ? Either2.t2(RelativePattern.fromJson(value as Map<String, Object?>))
           : throw '$value was not one of (LspPattern, RelativePattern)';
+}
+
+Either2<String, StringValue> _eitherStringStringValue(Object? value) {
+  return value is String
+      ? Either2.t1(value)
+      : StringValue.canParse(value, nullLspJsonReporter)
+          ? Either2.t2(StringValue.fromJson(value as Map<String, Object?>))
+          : throw '$value was not one of (String, StringValue)';
 }
 
 Either2<TextDocumentContentChangeEvent1, TextDocumentContentChangeEvent2>


### PR DESCRIPTION
- Re-generates `protocol_generated.dart`
- Updates readme example with missing `await connection.listen()` call.

Fixes: #6 